### PR TITLE
Refactor knowledge graph LLM pipeline with LangChain factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,9 @@ flowchart TD
     G --> H[process_with_llm]
     
     %% LLM processing
-    H --> I[call_llm]
+    H --> I[LLMService]
+    I --> I1[PluggableChainFactory]
+    I --> I2[PromptRegistry]
     I --> J[extract_json_from_text]
     
     %% Entity standardization phase
@@ -313,7 +315,7 @@ flowchart TD
     F --> W[JSON Data Export]
     
     %% Prompts usage
-    Y[prompts.py] --> H
+    Y[prompts.py] --> I2
     Y --> L1
     Y --> N2
     Y --> N3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,9 @@ dependencies = [
     "pyvis-network>=0.0.6",
     "requests>=2.32.3",
     "tomli>=2.2.1",
-    "python-louvain>=0.16"
+    "python-louvain>=0.16",
+    "langchain-core>=0.2.9",
+    "langchain-openai>=0.1.23"
 ]
 
 [build-system]

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,3 +33,6 @@ traitlets==5.14.3
 tzdata==2025.1
 urllib3==2.3.0
 wcwidth==0.2.13
+langchain-core==0.2.9
+langchain-openai==0.1.23
+openai==1.58.1

--- a/src/generate_graph.py
+++ b/src/generate_graph.py
@@ -12,4 +12,4 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from src.knowledge_graph.main import main
 
 if __name__ == "__main__":
-    main() 
+    main()

--- a/src/knowledge_graph/__init__.py
+++ b/src/knowledge_graph/__init__.py
@@ -5,7 +5,7 @@ A tool that takes text input and generates an interactive knowledge graph visual
 """
 
 from src.knowledge_graph.visualization import visualize_knowledge_graph, sample_data_visualization
-from src.knowledge_graph.llm import call_llm, extract_json_from_text
+from src.knowledge_graph.llm import LLMService, extract_json_from_text, service_from_config
 from src.knowledge_graph.config import load_config
 
 __version__ = "0.1.0"

--- a/src/knowledge_graph/chain_factory.py
+++ b/src/knowledge_graph/chain_factory.py
@@ -1,0 +1,83 @@
+"""Factory utilities for constructing LangChain chat pipelines."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Dict
+
+from langchain_openai import ChatOpenAI
+from langchain_core.output_parsers import StrOutputParser
+from langchain_core.prompts import ChatPromptTemplate
+from langchain_core.runnables import Runnable
+
+
+@dataclass(frozen=True)
+class LLMSettings:
+    """Configuration for creating chat model instances."""
+
+    model: str
+    api_key: str
+    max_tokens: int
+    temperature: float
+    base_url: str | None = None
+
+
+@dataclass(frozen=True)
+class PromptTemplateConfig:
+    """Container describing a chat prompt template."""
+
+    name: str
+    system_template: str
+    user_template: str
+    chain_type: str = "chat-generic"
+
+
+class PluggableChainFactory:
+    """Factory that creates chat pipelines using registered builders."""
+
+    def __init__(self) -> None:
+        self._registry: Dict[str, Callable[[LLMSettings, PromptTemplateConfig], Runnable]] = {}
+
+    def register(self, name: str, builder: Callable[[LLMSettings, PromptTemplateConfig], Runnable]) -> None:
+        """Register a builder function for a given chain type."""
+
+        self._registry[name] = builder
+
+    def create(self, name: str, settings: LLMSettings, prompt: PromptTemplateConfig) -> Runnable:
+        """Create a runnable chain for the given settings and prompt."""
+
+        try:
+            builder = self._registry[name]
+        except KeyError as exc:
+            raise ValueError(f"Unknown chain type '{name}'") from exc
+        return builder(settings, prompt)
+
+
+def _build_chat_chain(settings: LLMSettings, prompt: PromptTemplateConfig) -> Runnable:
+    """Build a simple chat pipeline that returns plain text responses."""
+
+    chat_prompt = ChatPromptTemplate.from_messages(
+        [
+            ("system", prompt.system_template),
+            ("user", prompt.user_template),
+        ]
+    )
+
+    chat_model = ChatOpenAI(
+        model=settings.model,
+        openai_api_key=settings.api_key,
+        temperature=settings.temperature,
+        max_tokens=settings.max_tokens,
+        openai_api_base=settings.base_url,
+    )
+
+    return chat_prompt | chat_model | StrOutputParser()
+
+
+def default_factory() -> PluggableChainFactory:
+    """Create a factory instance with default builders registered."""
+
+    factory = PluggableChainFactory()
+    factory.register("chat-generic", _build_chat_chain)
+    return factory
+

--- a/src/knowledge_graph/entity_standardization.py
+++ b/src/knowledge_graph/entity_standardization.py
@@ -1,17 +1,19 @@
 """Entity standardization and relationship inference for knowledge graphs."""
+
+from __future__ import annotations
+
 import re
 from collections import defaultdict
-from src.knowledge_graph.llm import call_llm
+from typing import Any, Dict, Iterable, List, Sequence, Set
+
+from src.knowledge_graph.llm import LLMService, extract_json_from_text
 from src.knowledge_graph.prompts import (
-    ENTITY_RESOLUTION_SYSTEM_PROMPT, 
-    get_entity_resolution_user_prompt,
-    RELATIONSHIP_INFERENCE_SYSTEM_PROMPT,
-    get_relationship_inference_user_prompt,
-    WITHIN_COMMUNITY_INFERENCE_SYSTEM_PROMPT,
-    get_within_community_inference_user_prompt
+    ENTITY_RESOLUTION_PROMPT,
+    RELATIONSHIP_INFERENCE_PROMPT,
+    WITHIN_COMMUNITY_INFERENCE_PROMPT,
 )
 
-def limit_predicate_length(predicate, max_words=3):
+def limit_predicate_length(predicate: str, max_words: int = 3) -> str:
     """
     Enforce a maximum word limit on predicates.
     
@@ -37,24 +39,20 @@ def limit_predicate_length(predicate, max_words=3):
     
     return shortened
 
-def standardize_entities(triples, config):
-    """
-    Standardize entity names across all triples.
-    
-    Args:
-        triples: List of dictionaries with 'subject', 'predicate', and 'object' keys
-        config: Configuration dictionary
-        
-    Returns:
-        List of triples with standardized entity names
-    """
+def standardize_entities(
+    triples: Sequence[Dict[str, Any]],
+    config: Dict[str, Any],
+    llm_service: LLMService | None = None,
+    debug: bool = False,
+) -> List[Dict[str, Any]]:
+    """Standardize entity names across all triples."""
     if not triples:
         return triples
     
     print("Standardizing entity names across all triples...")
     
     # Validate input triples to ensure they have the required fields
-    valid_triples = []
+    valid_triples: List[Dict[str, Any]] = []
     invalid_count = 0
     
     for triple in triples:
@@ -162,7 +160,7 @@ def standardize_entities(triples, config):
         standardized_entities[entity] = standard
     
     # 5. Apply standardization to all triples
-    standardized_triples = []
+    standardized_triples: List[Dict[str, Any]] = []
     for triple in valid_triples:
         subj_lower = triple["subject"].lower()
         obj_lower = triple["object"].lower()
@@ -177,7 +175,14 @@ def standardize_entities(triples, config):
     
     # 6. Optional: Use LLM to help with entity resolution for ambiguous cases
     if config.get("standardization", {}).get("use_llm_for_entities", False):
-        standardized_triples = _resolve_entities_with_llm(standardized_triples, config)
+        if llm_service is None:
+            print("LLM service unavailable; skipping LLM-based entity resolution")
+        else:
+            standardized_triples = _resolve_entities_with_llm(
+                standardized_triples,
+                llm_service,
+                debug=debug,
+            )
     
     # 7. Filter out self-referencing triples
     filtered_triples = [triple for triple in standardized_triples if triple["subject"] != triple["object"]]
@@ -187,24 +192,21 @@ def standardize_entities(triples, config):
     print(f"Standardized {len(all_entities)} entities into {len(set(standardized_entities.values()))} standard forms")
     return filtered_triples
 
-def infer_relationships(triples, config):
-    """
-    Infer additional relationships between entities to reduce isolated communities.
-    
-    Args:
-        triples: List of dictionaries with standardized entity names
-        config: Configuration dictionary
-        
-    Returns:
-        List of triples with additional inferred relationships
-    """
+def infer_relationships(
+    triples: Sequence[Dict[str, Any]],
+    config: Dict[str, Any],
+    llm_service: LLMService | None = None,
+    debug: bool = False,
+) -> List[Dict[str, Any]]:
+    """Infer additional relationships between entities to reduce isolated communities."""
+
     if not triples or len(triples) < 2:
-        return triples
+        return list(triples)
     
     print("Inferring additional relationships between entities...")
     
     # Validate input triples to ensure they have the required fields
-    valid_triples = []
+    valid_triples: List[Dict[str, Any]] = []
     invalid_count = 0
     
     for triple in triples:
@@ -234,19 +236,30 @@ def infer_relationships(triples, config):
     communities = _identify_communities(graph)
     print(f"Identified {len(communities)} disconnected communities in the graph")
     
-    new_triples = []
+    new_triples: List[Dict[str, Any]] = []
     
     # Use LLM to infer relationships between isolated communities if configured
     if config.get("inference", {}).get("use_llm_for_inference", True):
-        # Infer relationships between different communities
-        community_triples = _infer_relationships_with_llm(valid_triples, communities, config)
-        if community_triples:
-            new_triples.extend(community_triples)
-            
-        # Infer relationships within the same communities for semantically related entities
-        within_community_triples = _infer_within_community_relationships(valid_triples, communities, config)
-        if within_community_triples:
-            new_triples.extend(within_community_triples)
+        if llm_service is None:
+            print("LLM service unavailable; skipping LLM-based relationship inference")
+        else:
+            community_triples = _infer_relationships_with_llm(
+                valid_triples,
+                communities,
+                llm_service,
+                debug=debug,
+            )
+            if community_triples:
+                new_triples.extend(community_triples)
+
+            within_community_triples = _infer_within_community_relationships(
+                valid_triples,
+                communities,
+                llm_service,
+                debug=debug,
+            )
+            if within_community_triples:
+                new_triples.extend(within_community_triples)
     
     # Apply transitive inference rules
     transitive_triples = _apply_transitive_inference(valid_triples, graph)
@@ -381,186 +394,143 @@ def _deduplicate_triples(triples):
     
     return list(unique_triples.values())
 
-def _resolve_entities_with_llm(triples, config):
-    """
-    Use LLM to help resolve entity references and standardize entity names.
-    
-    Args:
-        triples: List of triples with potentially non-standardized entities
-        config: Configuration dictionary
-        
-    Returns:
-        List of triples with LLM-assisted entity standardization
-    """
-    # Extract all unique entities
-    all_entities = set()
+def _resolve_entities_with_llm(
+    triples: List[Dict[str, Any]],
+    llm_service: LLMService,
+    *,
+    debug: bool = False,
+) -> List[Dict[str, Any]]:
+    """Use an LLM chain to standardize ambiguous entity references."""
+
+    all_entities: Set[str] = set()
     for triple in triples:
         all_entities.add(triple["subject"])
         all_entities.add(triple["object"])
-    
-    # If there are too many entities, limit to the most frequent ones
+
     if len(all_entities) > 100:
-        # Count entity occurrences
-        entity_counts = defaultdict(int)
+        entity_counts: Dict[str, int] = defaultdict(int)
         for triple in triples:
             entity_counts[triple["subject"]] += 1
             entity_counts[triple["object"]] += 1
-        
-        # Keep only the top 100 most frequent entities
-        all_entities = {entity for entity, count in 
-                       sorted(entity_counts.items(), key=lambda x: -x[1])[:100]}
-    
-    # Prepare prompt for LLM
+        top_entities = sorted(entity_counts.items(), key=lambda item: -item[1])[:100]
+        all_entities = {entity for entity, _ in top_entities}
+
+    if not all_entities:
+        return triples
+
     entity_list = "\n".join(sorted(all_entities))
-    system_prompt = ENTITY_RESOLUTION_SYSTEM_PROMPT
-    user_prompt = get_entity_resolution_user_prompt(entity_list)
-    
+
     try:
-        # LLM configuration
-        model = config["llm"]["model"]
-        api_key = config["llm"]["api_key"]
-        max_tokens = config["llm"]["max_tokens"]
-        temperature = config["llm"]["temperature"]
-        base_url = config["llm"]["base_url"]
-        
-        # Call LLM
-        response = call_llm(model, user_prompt, api_key, system_prompt, max_tokens, temperature, base_url)
-        
-        # Extract JSON mapping
-        import json
-        from src.knowledge_graph.llm import extract_json_from_text
-        
-        entity_mapping = extract_json_from_text(response)
-        
-        if entity_mapping and isinstance(entity_mapping, dict):
-            # Apply the mapping to standardize entities
-            entity_to_standard = {}
-            for standard, variants in entity_mapping.items():
-                for variant in variants:
-                    entity_to_standard[variant] = standard
-                # Also map the standard form to itself
-                entity_to_standard[standard] = standard
-            
-            # Apply standardization to triples
-            for triple in triples:
-                triple["subject"] = entity_to_standard.get(triple["subject"], triple["subject"])
-                triple["object"] = entity_to_standard.get(triple["object"], triple["object"])
-                
-            print(f"Applied LLM-based entity standardization for {len(entity_mapping)} entity groups")
-        else:
-            print("Could not extract valid entity mapping from LLM response")
-    
-    except Exception as e:
-        print(f"Error in LLM-based entity resolution: {e}")
-    
+        response = llm_service.invoke(
+            ENTITY_RESOLUTION_PROMPT.name,
+            {"entity_list": entity_list},
+            debug=debug,
+        )
+    except Exception as exc:
+        print(f"Error in LLM-based entity resolution: {exc}")
+        return triples
+
+    entity_mapping = extract_json_from_text(response)
+
+    if not entity_mapping or not isinstance(entity_mapping, dict):
+        print("Could not extract valid entity mapping from LLM response")
+        return triples
+
+    entity_to_standard: Dict[str, str] = {}
+    for standard, variants in entity_mapping.items():
+        for variant in variants:
+            entity_to_standard[variant] = standard
+        entity_to_standard[standard] = standard
+
+    for triple in triples:
+        triple["subject"] = entity_to_standard.get(triple["subject"], triple["subject"])
+        triple["object"] = entity_to_standard.get(triple["object"], triple["object"])
+
+    print(f"Applied LLM-based entity standardization for {len(entity_mapping)} entity groups")
     return triples
 
-def _infer_relationships_with_llm(triples, communities, config):
-    """
-    Use LLM to infer relationships between disconnected communities.
-    
-    Args:
-        triples: List of existing triples
-        communities: List of community sets
-        config: Configuration dictionary
-        
-    Returns:
-        List of new inferred triples
-    """
-    # Skip if there's only one community
+def _infer_relationships_with_llm(
+    triples: Sequence[Dict[str, Any]],
+    communities: Sequence[Set[str]],
+    llm_service: LLMService,
+    *,
+    debug: bool = False,
+) -> List[Dict[str, Any]]:
+    """Use an LLM to infer relationships between disconnected communities."""
+
     if len(communities) <= 1:
         print("Only one community found, skipping LLM-based relationship inference")
         return []
-    
-    # Focus on the largest communities
+
     large_communities = sorted(communities, key=len, reverse=True)[:5]
-    
-    # For each pair of large communities, try to infer relationships
-    new_triples = []
-    
+    new_triples: List[Dict[str, Any]] = []
+
     for i, comm1 in enumerate(large_communities):
         for j, comm2 in enumerate(large_communities):
             if i >= j:
-                continue  # Skip self-comparisons and duplicates
+                continue
+
+            rep1 = list(comm1)[: min(5, len(comm1))]
+            rep2 = list(comm2)[: min(5, len(comm2))]
             
-            # Select representative entities from each community
-            rep1 = list(comm1)[:min(5, len(comm1))]
-            rep2 = list(comm2)[:min(5, len(comm2))]
-            
-            # Prepare relevant existing triples for context
-            context_triples = []
-            for triple in triples:
-                if triple["subject"] in rep1 or triple["subject"] in rep2 or \
-                   triple["object"] in rep1 or triple["object"] in rep2:
-                    context_triples.append(triple)
-            
-            # Limit context size
-            if len(context_triples) > 20:
-                context_triples = context_triples[:20]
-            
-            # Convert triples to text for prompt
-            triples_text = "\n".join([
-                f"{t['subject']} {t['predicate']} {t['object']}"
-                for t in context_triples
-            ])
-            
-            # Prepare entity lists
+            context_triples = [
+                triple
+                for triple in triples
+                if triple["subject"] in rep1
+                or triple["subject"] in rep2
+                or triple["object"] in rep1
+                or triple["object"] in rep2
+            ][:20]
+
+            triples_text = "\n".join(
+                f"{t['subject']} {t['predicate']} {t['object']}" for t in context_triples
+            )
+
             entities1 = ", ".join(rep1)
             entities2 = ", ".join(rep2)
-            
-            # Create prompt for LLM
-            system_prompt = RELATIONSHIP_INFERENCE_SYSTEM_PROMPT
-            user_prompt = get_relationship_inference_user_prompt(entities1, entities2, triples_text)
-            
-            try:
-                # LLM configuration
-                model = config["llm"]["model"]
-                api_key = config["llm"]["api_key"]
-                max_tokens = config["llm"]["max_tokens"]
-                temperature = config["llm"]["temperature"]
-                base_url = config["llm"]["base_url"]
-                
-                # Call LLM
-                response = call_llm(model, user_prompt, api_key, system_prompt, max_tokens, temperature, base_url)
-                
-                # Extract JSON results
-                from src.knowledge_graph.llm import extract_json_from_text
-                inferred_triples = extract_json_from_text(response)
-                
-                if inferred_triples and isinstance(inferred_triples, list):
-                    # Mark as inferred and add to new triples
-                    for triple in inferred_triples:
-                        if "subject" in triple and "predicate" in triple and "object" in triple:
-                            # Skip self-referencing triples
-                            if triple["subject"] == triple["object"]:
-                                continue
-                            triple["inferred"] = True
-                            triple["predicate"] = limit_predicate_length(triple["predicate"])
-                            new_triples.append(triple)
-                    
-                    print(f"Inferred {len(new_triples)} new relationships between communities")
-                else:
-                    print("Could not extract valid inferred relationships from LLM response")
-            
-            except Exception as e:
-                print(f"Error in LLM-based relationship inference: {e}")
-    
-    return new_triples 
 
-def _infer_within_community_relationships(triples, communities, config):
-    """
-    Use LLM to infer relationships between entities within the same community.
-    Focus on entities that might be semantically related but not directly connected.
-    
-    Args:
-        triples: List of existing triples
-        communities: List of community sets
-        config: Configuration dictionary
-        
-    Returns:
-        List of new inferred triples
-    """
-    new_triples = []
+            try:
+                response = llm_service.invoke(
+                    RELATIONSHIP_INFERENCE_PROMPT.name,
+                    {
+                        "entities1": entities1,
+                        "entities2": entities2,
+                        "triples_text": triples_text,
+                    },
+                    debug=debug,
+                )
+            except Exception as exc:
+                print(f"Error in LLM-based relationship inference: {exc}")
+                continue
+
+            inferred_triples = extract_json_from_text(response)
+
+            if not inferred_triples or not isinstance(inferred_triples, list):
+                print("Could not extract valid inferred relationships from LLM response")
+                continue
+
+            for triple in inferred_triples:
+                if {"subject", "predicate", "object"}.issubset(triple):
+                    if triple["subject"] == triple["object"]:
+                        continue
+                    triple["inferred"] = True
+                    triple["predicate"] = limit_predicate_length(triple["predicate"])
+                    new_triples.append(triple)
+
+            print(f"Inferred {len(inferred_triples)} new relationships between communities")
+
+    return new_triples
+
+def _infer_within_community_relationships(
+    triples: Sequence[Dict[str, Any]],
+    communities: Sequence[Set[str]],
+    llm_service: LLMService,
+    *,
+    debug: bool = False,
+) -> List[Dict[str, Any]]:
+    """Use an LLM to infer relationships within a community."""
+
+    new_triples: List[Dict[str, Any]] = []
     
     # Process larger communities
     for community in sorted(communities, key=len, reverse=True)[:3]:
@@ -622,43 +592,35 @@ def _infer_within_community_relationships(triples, communities, config):
         # Create pairs text
         pairs_text = "\n".join([f"{a} and {b}" for a, b in disconnected_pairs])
         
-        # Create prompt for LLM
-        system_prompt = WITHIN_COMMUNITY_INFERENCE_SYSTEM_PROMPT
-        user_prompt = get_within_community_inference_user_prompt(pairs_text, triples_text)
-        
         try:
-            # LLM configuration
-            model = config["llm"]["model"]
-            api_key = config["llm"]["api_key"]
-            max_tokens = config["llm"]["max_tokens"]
-            temperature = config["llm"]["temperature"]
-            base_url = config["llm"]["base_url"]
-            
-            # Call LLM
-            response = call_llm(model, user_prompt, api_key, system_prompt, max_tokens, temperature, base_url)
-            
-            # Extract JSON results
-            from src.knowledge_graph.llm import extract_json_from_text
-            inferred_triples = extract_json_from_text(response)
-            
-            if inferred_triples and isinstance(inferred_triples, list):
-                # Mark as inferred and add to new triples
-                for triple in inferred_triples:
-                    if "subject" in triple and "predicate" in triple and "object" in triple:
-                        # Skip self-referencing triples
-                        if triple["subject"] == triple["object"]:
-                            continue
-                        triple["inferred"] = True
-                        triple["predicate"] = limit_predicate_length(triple["predicate"])
-                        new_triples.append(triple)
-                
-                print(f"Inferred {len(inferred_triples)} new relationships within communities")
-            else:
-                print("Could not extract valid inferred relationships from LLM response")
-        
-        except Exception as e:
-            print(f"Error in LLM-based relationship inference within communities: {e}")
-    
+            response = llm_service.invoke(
+                WITHIN_COMMUNITY_INFERENCE_PROMPT.name,
+                {
+                    "pairs_text": pairs_text,
+                    "triples_text": triples_text,
+                },
+                debug=debug,
+            )
+        except Exception as exc:
+            print(f"Error in LLM-based relationship inference within communities: {exc}")
+            continue
+
+        inferred_triples = extract_json_from_text(response)
+
+        if not inferred_triples or not isinstance(inferred_triples, list):
+            print("Could not extract valid inferred relationships from LLM response")
+            continue
+
+        for triple in inferred_triples:
+            if {"subject", "predicate", "object"}.issubset(triple):
+                if triple["subject"] == triple["object"]:
+                    continue
+                triple["inferred"] = True
+                triple["predicate"] = limit_predicate_length(triple["predicate"])
+                new_triples.append(triple)
+
+        print(f"Inferred {len(inferred_triples)} new relationships within communities")
+
     return new_triples
 
 def _infer_relationships_by_lexical_similarity(entities, triples):

--- a/src/knowledge_graph/llm.py
+++ b/src/knowledge_graph/llm.py
@@ -1,163 +1,154 @@
-"""LLM interaction utilities for knowledge graph generation."""
-import requests
+"""LLM utilities built on top of LangChain."""
+
+from __future__ import annotations
+
 import json
 import re
+from dataclasses import dataclass
+from typing import Any, Dict
 
-def call_llm(model, user_prompt, api_key, system_prompt=None, max_tokens=1000, temperature=0.2, base_url=None) -> str:
-    """
-    Call the language model API.
-    
-    Args:
-        model: The model name to use
-        user_prompt: The user prompt to send
-        api_key: The API key for authentication
-        system_prompt: Optional system prompt to set context
-        max_tokens: Maximum number of tokens to generate
-        temperature: Sampling temperature
-        base_url: The base URL for the API endpoint
-        
-    Returns:
-        The model's response as a string
-    """
-    headers = {
-        'Content-Type': 'application/json',
-        'Authorization': f"Bearer {api_key}"
-    }
-    
-    messages = []
-    
-    if system_prompt:
-        messages.append({
-            'role': 'system',
-            'content': system_prompt
-        })
-    
-    messages.append({
-        'role': 'user',
-        'content': [
-            {
-                'type': 'text',
-                'text': user_prompt
-            }
-        ]
-    })
-    
-    payload = {
-        'model': model,
-        'messages': messages,
-        'max_tokens': max_tokens,
-        'temperature': temperature
-    }
-    
-    response = requests.post(
-        base_url,
-        headers=headers,
-        json=payload
+from langchain_core.runnables import Runnable
+
+from src.knowledge_graph.chain_factory import LLMSettings, PluggableChainFactory, default_factory
+from src.knowledge_graph.prompts import PromptRegistry
+
+
+@dataclass
+class LLMService:
+    """Service wrapper responsible for orchestrating LangChain pipelines."""
+
+    settings: LLMSettings
+    factory: PluggableChainFactory
+    prompts: PromptRegistry
+    _chain_cache: Dict[str, Runnable]
+
+    def __init__(
+        self,
+        settings: LLMSettings,
+        factory: PluggableChainFactory | None = None,
+        prompts: PromptRegistry | None = None,
+    ) -> None:
+        self.settings = settings
+        self.factory = factory or default_factory()
+        self.prompts = prompts or PromptRegistry()
+        self._chain_cache = {}
+
+    def invoke(self, prompt_name: str, variables: Dict[str, Any], debug: bool = False) -> str:
+        """Execute the registered chain and return the raw text response."""
+
+        chain = self._get_chain(prompt_name)
+        response = chain.invoke(variables)
+
+        if debug:
+            print("Raw LLM response:")
+            print(response)
+            print("\n---\n")
+
+        return response
+
+    def _get_chain(self, prompt_name: str) -> Runnable:
+        """Return a cached chain instance for the requested prompt."""
+
+        if prompt_name not in self._chain_cache:
+            prompt_config = self.prompts.get(prompt_name)
+            self._chain_cache[prompt_name] = self.factory.create(
+                prompt_config.chain_type,
+                self.settings,
+                prompt_config,
+            )
+        return self._chain_cache[prompt_name]
+
+
+def service_from_config(config: Dict[str, Any]) -> LLMService:
+    """Instantiate :class:`LLMService` using configuration dictionary values."""
+
+    llm_config = config.get("llm", {})
+
+    required_fields = {"model", "api_key"}
+    missing = [field for field in required_fields if field not in llm_config]
+    if missing:
+        raise ValueError(f"Missing LLM configuration fields: {', '.join(sorted(missing))}")
+
+    settings = LLMSettings(
+        model=llm_config["model"],
+        api_key=llm_config["api_key"],
+        max_tokens=int(llm_config.get("max_tokens", 1000)),
+        temperature=float(llm_config.get("temperature", 0.2)),
+        base_url=llm_config.get("base_url"),
     )
-    
-    if response.status_code == 200:
-        return response.json()['choices'][0]['message']['content']
-    else:
-        raise Exception(f"API request failed: {response.text}")
 
-def extract_json_from_text(text):
-    """
-    Extract JSON array from text that might contain additional content.
-    
-    Args:
-        text: Text that may contain JSON
-        
-    Returns:
-        The parsed JSON if found, None otherwise
-    """
-    # First, check if the text is wrapped in code blocks with triple backticks
-    code_block_pattern = r'```(?:json)?\s*([\s\S]*?)```'
+    return LLMService(settings)
+
+
+def extract_json_from_text(text: str) -> Any:
+    """Extract JSON data from free-form text produced by an LLM."""
+
+    code_block_pattern = r"```(?:json)?\s*([\s\S]*?)```"
     code_match = re.search(code_block_pattern, text)
     if code_match:
         text = code_match.group(1).strip()
         print("Found JSON in code block, extracting content...")
-    
+
     try:
-        # Try direct parsing in case the response is already clean JSON
         return json.loads(text)
     except json.JSONDecodeError:
-        # Look for opening and closing brackets of a JSON array
-        start_idx = text.find('[')
+        start_idx = text.find("[")
         if start_idx == -1:
             print("No JSON array start found in text")
             return None
-            
-        # Simple bracket counting to find matching closing bracket
+
         bracket_count = 0
         complete_json = False
-        for i in range(start_idx, len(text)):
-            if text[i] == '[':
+        json_str = ""
+        for i, char in enumerate(text[start_idx:], start=start_idx):
+            if char == "[":
                 bracket_count += 1
-            elif text[i] == ']':
+            elif char == "]":
                 bracket_count -= 1
                 if bracket_count == 0:
-                    # Found the matching closing bracket
-                    json_str = text[start_idx:i+1]
+                    json_str = text[start_idx : i + 1]
                     complete_json = True
                     break
-        
-        # Handle complete JSON array
+
         if complete_json:
             try:
                 return json.loads(json_str)
             except json.JSONDecodeError:
-                print("Found JSON-like structure but couldn't parse it.")
-                print("Trying to fix common formatting issues...")
-                
-                # Try to fix missing quotes around keys
-                fixed_json = re.sub(r'(\s*)(\w+)(\s*):(\s*)', r'\1"\2"\3:\4', json_str)
-                # Fix trailing commas
-                fixed_json = re.sub(r',(\s*[\]}])', r'\1', fixed_json)
-                
+                print("Found JSON-like structure but couldn't parse it. Attempting repairs...")
+                fixed_json = re.sub(r"(\s*)(\w+)(\s*):(\s*)", r'\1"\2"\3:\4', json_str)
+                fixed_json = re.sub(r",(\s*[\]}])", r"\1", fixed_json)
                 try:
                     return json.loads(fixed_json)
-                except:
+                except json.JSONDecodeError:
                     print("Could not fix JSON format issues")
         else:
-            # Handle incomplete JSON - try to complete it
             print("Found incomplete JSON array, attempting to complete it...")
-            
-            # Get all complete objects from the array
             objects = []
             obj_start = -1
-            obj_end = -1
             brace_count = 0
-            
-            # First find all complete objects
-            for i in range(start_idx + 1, len(text)):
-                if text[i] == '{':
+            for i, char in enumerate(text[start_idx + 1 :], start=start_idx + 1):
+                if char == "{":
                     if brace_count == 0:
                         obj_start = i
                     brace_count += 1
-                elif text[i] == '}':
+                elif char == "}":
                     brace_count -= 1
-                    if brace_count == 0:
-                        obj_end = i
-                        objects.append(text[obj_start:obj_end+1])
-            
+                    if brace_count == 0 and obj_start != -1:
+                        objects.append(text[obj_start : i + 1])
+
             if objects:
-                # Reconstruct a valid JSON array with complete objects
                 reconstructed_json = "[\n" + ",\n".join(objects) + "\n]"
                 try:
                     return json.loads(reconstructed_json)
                 except json.JSONDecodeError:
-                    print("Couldn't parse reconstructed JSON array.")
-                    print("Trying to fix common formatting issues...")
-                    
-                    # Try to fix missing quotes around keys
-                    fixed_json = re.sub(r'(\s*)(\w+)(\s*):(\s*)', r'\1"\2"\3:\4', reconstructed_json)
-                    # Fix trailing commas
-                    fixed_json = re.sub(r',(\s*[\]}])', r'\1', fixed_json)
-                    
+                    print("Couldn't parse reconstructed JSON array. Attempting repairs...")
+                    fixed_json = re.sub(r"(\s*)(\w+)(\s*):(\s*)", r'\1"\2"\3:\4', reconstructed_json)
+                    fixed_json = re.sub(r",(\s*[\]}])", r"\1", fixed_json)
                     try:
                         return json.loads(fixed_json)
-                    except:
+                    except json.JSONDecodeError:
                         print("Could not fix JSON format issues in reconstructed array")
-            
+
         print("No complete JSON array could be extracted")
-        return None 
+        return None
+

--- a/src/knowledge_graph/main.py
+++ b/src/knowledge_graph/main.py
@@ -10,84 +10,62 @@ import sys
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 
 from src.knowledge_graph.config import load_config
-from src.knowledge_graph.llm import call_llm, extract_json_from_text
+from src.knowledge_graph.llm import LLMService, extract_json_from_text, service_from_config
 from src.knowledge_graph.visualization import visualize_knowledge_graph, sample_data_visualization
 from src.knowledge_graph.text_utils import chunk_text
 from src.knowledge_graph.entity_standardization import standardize_entities, infer_relationships, limit_predicate_length
-from src.knowledge_graph.prompts import MAIN_SYSTEM_PROMPT, MAIN_USER_PROMPT
+from src.knowledge_graph.prompts import TRIPLE_EXTRACTION_PROMPT
 
-def process_with_llm(config, input_text, debug=False):
-    """
-    Process input text with LLM to extract triples.
-    
-    Args:
-        config: Configuration dictionary
-        input_text: Text to analyze
-        debug: If True, print detailed debug information
-        
-    Returns:
-        List of extracted triples or None if processing failed
-    """
-    # Use prompts from the prompts module
-    system_prompt = MAIN_SYSTEM_PROMPT
-    user_prompt = MAIN_USER_PROMPT
-    user_prompt += f"```\n{input_text}```\n" 
+def process_with_llm(llm_service: LLMService, input_text: str, debug: bool = False):
+    """Process input text with the LLM service to extract triples."""
 
-    # LLM configuration
-    model = config["llm"]["model"]
-    api_key = config["llm"]["api_key"]
-    max_tokens = config["llm"]["max_tokens"]
-    temperature = config["llm"]["temperature"]
-    base_url = config["llm"]["base_url"]
-    
-    # Process with LLM
-    metadata = {}
-    response = call_llm(model, user_prompt, api_key, system_prompt, max_tokens, temperature, base_url)
-    
-    # Print raw response only if debug mode is on
-    if debug:
-        print("Raw LLM response:")
-        print(response)
-        print("\n---\n")
-    
-    # Extract JSON from the response
+    try:
+        response = llm_service.invoke(
+            TRIPLE_EXTRACTION_PROMPT.name,
+            {"input_text": input_text},
+            debug=debug,
+        )
+    except Exception as exc:
+        print(f"Error while invoking LLM: {exc}")
+        return None
+
     result = extract_json_from_text(response)
-    
-    if result:
-        # Validate and filter triples to ensure they have all required fields
-        valid_triples = []
-        invalid_count = 0
-        
-        for item in result:
-            if isinstance(item, dict) and "subject" in item and "predicate" in item and "object" in item:
-                # Add metadata to valid items
-                valid_triples.append(dict(item, **metadata))
-            else:
-                invalid_count += 1
-        
-        if invalid_count > 0:
-            print(f"Warning: Filtered out {invalid_count} invalid triples missing required fields")
-        
-        if not valid_triples:
-            print("Error: No valid triples found in LLM response")
-            return None
-        
-        # Apply predicate length limit to all valid triples
-        for triple in valid_triples:
-            triple["predicate"] = limit_predicate_length(triple["predicate"])
-        
-        # Print extracted JSON only if debug mode is on
-        if debug:
-            print("Extracted JSON:")
-            print(json.dumps(valid_triples, indent=2))  # Pretty print the JSON
-        
-        return valid_triples
-    else:
-        # Always print error messages even if debug is off
+
+    if not result:
         print("\n\nERROR ### Could not extract valid JSON from response: ", response, "\n\n")
         return None
 
-def process_text_in_chunks(config, full_text, debug=False):
+    valid_triples = []
+    invalid_count = 0
+
+    for item in result:
+        if isinstance(item, dict) and {"subject", "predicate", "object"}.issubset(item):
+            valid_triples.append(dict(item))
+        else:
+            invalid_count += 1
+
+    if invalid_count > 0:
+        print(f"Warning: Filtered out {invalid_count} invalid triples missing required fields")
+
+    if not valid_triples:
+        print("Error: No valid triples found in LLM response")
+        return None
+
+    for triple in valid_triples:
+        triple["predicate"] = limit_predicate_length(triple["predicate"])
+
+    if debug:
+        print("Extracted JSON:")
+        print(json.dumps(valid_triples, indent=2))
+
+    return valid_triples
+
+def process_text_in_chunks(
+    config,
+    full_text: str,
+    llm_service: LLMService,
+    debug: bool = False,
+):
     """
     Process a large text by breaking it into chunks with overlap,
     and then processing each chunk separately.
@@ -118,7 +96,7 @@ def process_text_in_chunks(config, full_text, debug=False):
         print(f"Processing chunk {i+1}/{len(text_chunks)} ({len(chunk.split())} words)")
         
         # Process the chunk with LLM
-        chunk_results = process_with_llm(config, chunk, debug)
+        chunk_results = process_with_llm(llm_service, chunk, debug)
         
         if chunk_results:
             # Add chunk information to each triple
@@ -139,7 +117,7 @@ def process_text_in_chunks(config, full_text, debug=False):
         print("="*50)
         print(f"Starting with {len(all_results)} triples and {len(get_unique_entities(all_results))} unique entities")
         
-        all_results = standardize_entities(all_results, config)
+        all_results = standardize_entities(all_results, config, llm_service=llm_service, debug=debug)
         
         print(f"After standardization: {len(all_results)} triples and {len(get_unique_entities(all_results))} unique entities")
     
@@ -159,7 +137,7 @@ def process_text_in_chunks(config, full_text, debug=False):
         for pred, count in sorted(relationship_counts.items(), key=lambda x: x[1], reverse=True)[:5]:
             print(f"  - {pred}: {count} occurrences")
         
-        all_results = infer_relationships(all_results, config)
+        all_results = infer_relationships(all_results, config, llm_service=llm_service, debug=debug)
         
         # Count relationships after inference
         relationship_counts_after = {}
@@ -178,15 +156,8 @@ def process_text_in_chunks(config, full_text, debug=False):
     return all_results
 
 def get_unique_entities(triples):
-    """
-    Get the set of unique entities from the triples.
-    
-    Args:
-        triples: List of triple dictionaries
-        
-    Returns:
-        Set of unique entity names
-    """
+    """Return the set of unique entities contained in the triples."""
+
     entities = set()
     for triple in triples:
         if not isinstance(triple, dict):
@@ -225,6 +196,12 @@ def main():
         print(f"To view the visualization, open the following file in your browser:")
         print(f"file://{os.path.abspath(args.output)}")
         return
+
+    try:
+        llm_service = service_from_config(config)
+    except ValueError as exc:
+        print(f"Invalid LLM configuration: {exc}")
+        return
     
     # For normal processing, input file is required
     if not args.input:
@@ -248,7 +225,7 @@ def main():
         return
     
     # Process text in chunks
-    result = process_text_in_chunks(config, input_text, args.debug)
+    result = process_text_in_chunks(config, input_text, llm_service, debug=args.debug)
     
     if result:
         # Save the raw data as JSON for potential reuse
@@ -274,4 +251,4 @@ def main():
         print("Knowledge graph generation failed due to errors in LLM processing.")
 
 if __name__ == "__main__":
-    main() 
+    main()

--- a/src/knowledge_graph/prompts.py
+++ b/src/knowledge_graph/prompts.py
@@ -1,147 +1,140 @@
-"""Centralized repository for all LLM prompts used in the knowledge graph system."""
+"""Centralized management of all prompts used by the knowledge graph system."""
 
-# Phase 1: Main extraction prompts
-MAIN_SYSTEM_PROMPT = """
-You are an advanced AI system specialized in knowledge extraction and knowledge graph generation.
-Your expertise includes identifying consistent entity references and meaningful relationships in text.
-CRITICAL INSTRUCTION: All relationships (predicates) MUST be no more than 3 words maximum. Ideally 1-2 words. This is a hard limit.
-"""
+from __future__ import annotations
 
-MAIN_USER_PROMPT = """
-Your task: Read the text below (delimited by triple backticks) and identify all Subject-Predicate-Object (S-P-O) relationships in each sentence. Then produce a single JSON array of objects, each representing one triple.
+from typing import Dict
 
-Follow these rules carefully:
+from src.knowledge_graph.chain_factory import PromptTemplateConfig
 
-- Entity Consistency: Use consistent names for entities throughout the document. For example, if "John Smith" is mentioned as "John", "Mr. Smith", and "John Smith" in different places, use a single consistent form (preferably the most complete one) in all triples.
-- Atomic Terms: Identify distinct key terms (e.g., objects, locations, organizations, acronyms, people, conditions, concepts, feelings). Avoid merging multiple ideas into one term (they should be as "atomistic" as possible).
-- Unified References: Replace any pronouns (e.g., "he," "she," "it," "they," etc.) with the actual referenced entity, if identifiable.
-- Pairwise Relationships: If multiple terms co-occur in the same sentence (or a short paragraph that makes them contextually related), create one triple for each pair that has a meaningful relationship.
-- CRITICAL INSTRUCTION: Predicates MUST be 1-3 words maximum. Never more than 3 words. Keep them extremely concise.
-- Ensure that all possible relationships are identified in the text and are captured in an S-P-O relation.
-- Standardize terminology: If the same concept appears with slight variations (e.g., "artificial intelligence" and "AI"), use the most common or canonical form consistently.
-- Make all the text of S-P-O text lower-case, even Names of people and places.
-- If a person is mentioned by name, create a relation to their location, profession and what they are known for (invented, wrote, started, title, etc.) if known and if it fits the context of the informaiton. 
 
-Important Considerations:
-- Aim for precision in entity naming - use specific forms that distinguish between similar but different entities
-- Maximize connectedness by using identical entity names for the same concepts throughout the document
-- Consider the entire context when identifying entity references
-- ALL PREDICATES MUST BE 3 WORDS OR FEWER - this is a hard requirement
+TRIPLE_EXTRACTION_PROMPT = PromptTemplateConfig(
+    name="triple_extraction",
+    system_template=(
+        "You are an advanced AI system specialized in knowledge extraction and knowledge graph generation.\n"
+        "Your expertise includes identifying consistent entity references and meaningful relationships in text.\n"
+        "CRITICAL INSTRUCTION: All relationships (predicates) MUST be no more than 3 words maximum. Ideally 1-2 words."
+    ),
+    user_template=(
+        "Your task: Read the text below (delimited by triple backticks) and identify all Subject-Predicate-Object (S-P-O) "
+        "relationships in each sentence. Then produce a single JSON array of objects, each representing one triple.\n\n"
+        "Follow these rules carefully:\n\n"
+        "- Entity Consistency: Use consistent names for entities throughout the document. For example, if \"John Smith\" is "
+        "mentioned as \"John\", \"Mr. Smith\", and \"John Smith\" in different places, use a single consistent form "
+        "(preferably the most complete one) in all triples.\n"
+        "- Atomic Terms: Identify distinct key terms (e.g., objects, locations, organizations, acronyms, people, conditions, "
+        "concepts, feelings). Avoid merging multiple ideas into one term (they should be as atomistic as possible).\n"
+        "- Unified References: Replace any pronouns (e.g., he, she, it, they, etc.) with the actual referenced entity, if "
+        "identifiable.\n"
+        "- Pairwise Relationships: If multiple terms co-occur in the same sentence (or a short paragraph that makes them "
+        "contextually related), create one triple for each pair that has a meaningful relationship.\n"
+        "- CRITICAL INSTRUCTION: Predicates MUST be 1-3 words maximum. Never more than 3 words. Keep them extremely concise.\n"
+        "- Ensure that all possible relationships are identified in the text and are captured in an S-P-O relation.\n"
+        "- Standardize terminology: If the same concept appears with slight variations (e.g., \"artificial intelligence\" and "
+        "\"AI\"), use the most common or canonical form consistently.\n"
+        "- Make all the text of S-P-O text lower-case, even names of people and places.\n"
+        "- If a person is mentioned by name, create a relation to their location, profession, and what they are known for if it "
+        "fits the context.\n\n"
+        "Important Considerations:\n\n"
+        "- Aim for precision in entity naming - use specific forms that distinguish between similar but different entities.\n"
+        "- Maximize connectedness by using identical entity names for the same concepts throughout the document.\n"
+        "- Consider the entire context when identifying entity references.\n"
+        "- ALL PREDICATES MUST BE 3 WORDS OR FEWER - this is a hard requirement.\n\n"
+        "Output Requirements:\n\n"
+        "- Do not include any text or commentary outside of the JSON.\n"
+        "- Return only the JSON array, with each triple as an object containing \"subject\", \"predicate\", and \"object\".\n"
+        "- Make sure the JSON is valid and properly formatted.\n\n"
+        "Example of the desired output structure:\n\n"
+        "[\n  {\n    \"subject\": \"term a\",\n    \"predicate\": \"relates to\",\n    \"object\": \"term b\"\n  },\n  {\n    \"subject\": \"term c\",\n    \"predicate\": \"uses\",\n    \"object\": \"term d\"\n  }\n]\n\n"
+        "Important: Only output the JSON array (with the S-P-O objects) and nothing else.\n\n"
+        "Text to analyze (between triple backticks):\n"
+        "```{input_text}```"
+    ),
+)
 
-Output Requirements:
 
-- Do not include any text or commentary outside of the JSON.
-- Return only the JSON array, with each triple as an object containing "subject", "predicate", and "object".
-- Make sure the JSON is valid and properly formatted.
+ENTITY_RESOLUTION_PROMPT = PromptTemplateConfig(
+    name="entity_resolution",
+    system_template=(
+        "You are an expert in entity resolution and knowledge representation.\n"
+        "Your task is to standardize entity names from a knowledge graph to ensure consistency."
+    ),
+    user_template=(
+        "Below is a list of entity names extracted from a knowledge graph.\n"
+        "Some may refer to the same real-world entities but with different wording.\n\n"
+        "Please identify groups of entities that refer to the same concept, and provide a standardized name for each group.\n"
+        "Return your answer as a JSON object where the keys are the standardized names and the values are arrays of all variant "
+        "names that should map to that standard name. Only include entities that have multiple variants or need standardization.\n\n"
+        "Entity list:\n{entity_list}\n\n"
+        "Format your response as valid JSON like this:\n"
+        "{{\n  \"standardized name 1\": [\"variant 1\", \"variant 2\"],\n  \"standardized name 2\": [\"variant 3\", \"variant 4\", \"variant 5\"]\n}}"
+    ),
+)
 
-Example of the desired output structure:
 
-[
-  {
-    "subject": "Term A",
-    "predicate": "relates to",  // Notice: only 2 words
-    "object": "Term B"
-  },
-  {
-    "subject": "Term C",
-    "predicate": "uses",  // Notice: only 1 word
-    "object": "Term D"
-  }
-]
+RELATIONSHIP_INFERENCE_PROMPT = PromptTemplateConfig(
+    name="relationship_inference",
+    system_template=(
+        "You are an expert in knowledge representation and inference.\n"
+        "Your task is to infer plausible relationships between disconnected entities in a knowledge graph."
+    ),
+    user_template=(
+        "I have a knowledge graph with two disconnected communities of entities.\n\n"
+        "Community 1 entities: {entities1}\n"
+        "Community 2 entities: {entities2}\n\n"
+        "Here are some existing relationships involving these entities:\n{triples_text}\n\n"
+        "Please infer 2-3 plausible relationships between entities from Community 1 and entities from Community 2.\n"
+        "Return your answer as a JSON array of triples in the following format:\n\n"
+        "[\n  {{\n    \"subject\": \"entity from community 1\",\n    \"predicate\": \"inferred relationship\",\n    \"object\": \"entity from community 2\"\n  }},\n  ...\n]\n\n"
+        "Only include highly plausible relationships with clear predicates.\n"
+        "IMPORTANT: The inferred relationships (predicates) MUST be no more than 3 words maximum. Preferably 1-2 words. Never "
+        "more than 3.\n"
+        "For predicates, use short phrases that clearly describe the relationship.\n"
+        "IMPORTANT: Make sure the subject and object are different entities - avoid self-references."
+    ),
+)
 
-Important: Only output the JSON array (with the S-P-O objects) and nothing else
 
-Text to analyze (between triple backticks):
-"""
+WITHIN_COMMUNITY_INFERENCE_PROMPT = PromptTemplateConfig(
+    name="within_community_inference",
+    system_template=(
+        "You are an expert in knowledge representation and inference.\n"
+        "Your task is to infer plausible relationships between semantically related entities that are not yet connected in a "
+        "knowledge graph."
+    ),
+    user_template=(
+        "I have a knowledge graph with several entities that appear to be semantically related but are not directly connected.\n\n"
+        "Here are some pairs of entities that might be related:\n{pairs_text}\n\n"
+        "Here are some existing relationships involving these entities:\n{triples_text}\n\n"
+        "Please infer plausible relationships between these disconnected pairs.\n"
+        "Return your answer as a JSON array of triples in the following format:\n\n"
+        "[\n  {{\n    \"subject\": \"entity1\",\n    \"predicate\": \"inferred relationship\",\n    \"object\": \"entity2\"\n  }},\n  ...\n]\n\n"
+        "Only include highly plausible relationships with clear predicates.\n"
+        "IMPORTANT: The inferred relationships (predicates) MUST be no more than 3 words maximum. Preferably 1-2 words. Never "
+        "more than 3.\n"
+        "IMPORTANT: Make sure that the subject and object are different entities - avoid self-references."
+    ),
+)
 
-# Phase 2: Entity standardization prompts
-ENTITY_RESOLUTION_SYSTEM_PROMPT = """
-You are an expert in entity resolution and knowledge representation.
-Your task is to standardize entity names from a knowledge graph to ensure consistency.
-"""
 
-def get_entity_resolution_user_prompt(entity_list):
-    return f"""
-Below is a list of entity names extracted from a knowledge graph. 
-Some may refer to the same real-world entities but with different wording.
+class PromptRegistry:
+    """Provides access to the prompt templates used across the application."""
 
-Please identify groups of entities that refer to the same concept, and provide a standardized name for each group.
-Return your answer as a JSON object where the keys are the standardized names and the values are arrays of all variant names that should map to that standard name.
-Only include entities that have multiple variants or need standardization.
+    def __init__(self) -> None:
+        self._templates: Dict[str, PromptTemplateConfig] = {
+            template.name: template
+            for template in (
+                TRIPLE_EXTRACTION_PROMPT,
+                ENTITY_RESOLUTION_PROMPT,
+                RELATIONSHIP_INFERENCE_PROMPT,
+                WITHIN_COMMUNITY_INFERENCE_PROMPT,
+            )
+        }
 
-Entity list:
-{entity_list}
+    def get(self, name: str) -> PromptTemplateConfig:
+        """Return the prompt template registered under the provided name."""
 
-Format your response as valid JSON like this:
-{{
-  "standardized name 1": ["variant 1", "variant 2"],
-  "standardized name 2": ["variant 3", "variant 4", "variant 5"]
-}}
-"""
+        try:
+            return self._templates[name]
+        except KeyError as exc:
+            raise ValueError(f"Prompt '{name}' is not registered.") from exc
 
-# Phase 3: Community relationship inference prompts
-RELATIONSHIP_INFERENCE_SYSTEM_PROMPT = """
-You are an expert in knowledge representation and inference. 
-Your task is to infer plausible relationships between disconnected entities in a knowledge graph.
-"""
-
-def get_relationship_inference_user_prompt(entities1, entities2, triples_text):
-    return f"""
-I have a knowledge graph with two disconnected communities of entities. 
-
-Community 1 entities: {entities1}
-Community 2 entities: {entities2}
-
-Here are some existing relationships involving these entities:
-{triples_text}
-
-Please infer 2-3 plausible relationships between entities from Community 1 and entities from Community 2.
-Return your answer as a JSON array of triples in the following format:
-
-[
-  {{
-    "subject": "entity from community 1",
-    "predicate": "inferred relationship",
-    "object": "entity from community 2"
-  }},
-  ...
-]
-
-Only include highly plausible relationships with clear predicates.
-IMPORTANT: The inferred relationships (predicates) MUST be no more than 3 words maximum. Preferably 1-2 words. Never more than 3.
-For predicates, use short phrases that clearly describe the relationship.
-IMPORTANT: Make sure the subject and object are different entities - avoid self-references.
-"""
-
-# Phase 4: Within-community relationship inference prompts
-WITHIN_COMMUNITY_INFERENCE_SYSTEM_PROMPT = """
-You are an expert in knowledge representation and inference. 
-Your task is to infer plausible relationships between semantically related entities that are not yet connected in a knowledge graph.
-"""
-
-def get_within_community_inference_user_prompt(pairs_text, triples_text):
-    return f"""
-I have a knowledge graph with several entities that appear to be semantically related but are not directly connected.
-
-Here are some pairs of entities that might be related:
-{pairs_text}
-
-Here are some existing relationships involving these entities:
-{triples_text}
-
-Please infer plausible relationships between these disconnected pairs.
-Return your answer as a JSON array of triples in the following format:
-
-[
-  {{
-    "subject": "entity1",
-    "predicate": "inferred relationship",
-    "object": "entity2"
-  }},
-  ...
-]
-
-Only include highly plausible relationships with clear predicates.
-IMPORTANT: The inferred relationships (predicates) MUST be no more than 3 words maximum. Preferably 1-2 words. Never more than 3.
-IMPORTANT: Make sure that the subject and object are different entities - avoid self-references.
-""" 


### PR DESCRIPTION
## Summary
- introduce a LangChain-backed pluggable chain factory and prompt registry for building chat pipelines
- refactor the CLI workflow and entity utilities to rely on the shared LLM service instead of direct REST calls
- document the new architecture and add the required LangChain dependencies

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68da4c8406cc832884f1511a16041543